### PR TITLE
feat: add slider component

### DIFF
--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -1,13 +1,14 @@
 import { Box, CounterLabel } from "@primer/react";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 
 interface CommonProps {
   min: number;
   max: number;
-  value?: number;
+  value: number;
   displayValue?: boolean;
   orientation?: "horizontal" | "vertical";
   width?: string | number;
+  onChange: (value: number) => void;
 }
 
 type ConditionalProps =
@@ -31,12 +32,18 @@ export const Slider = ({
   displayValue = false,
   orientation = "horizontal",
   width = "200px",
+  onChange,
 }: SliderProps) => {
-  const [sliderVal, setSliderVal] = useState(value ?? 0);
+  const [sliderVal, setSliderVal] = useState(value);
+
+  useEffect(() => {
+    setSliderVal(value);
+  }, [value]);
 
   const handleSliderChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newValue = Number(event.target.value);
     setSliderVal(newValue);
+    onChange(newValue);
   };
 
   // Warning: unreliable

--- a/src/components/slider/Slider.tsx
+++ b/src/components/slider/Slider.tsx
@@ -1,5 +1,77 @@
-export const Slider = () => {
-  return <>Slider</>;
+import { Box, CounterLabel } from "@primer/react";
+import { ChangeEvent, useState } from "react";
+
+interface CommonProps {
+  min: number;
+  max: number;
+  value?: number;
+  displayValue?: boolean;
+  orientation?: "horizontal" | "vertical";
+  width?: string | number;
+}
+
+type ConditionalProps =
+  | {
+      markers: true;
+      step: number;
+    }
+  | {
+      markers?: false;
+      step?: number;
+    }
+
+export type SliderProps = CommonProps & ConditionalProps
+
+export const Slider = ({
+  min,
+  max,
+  value,
+  step,
+  markers = false,
+  displayValue = false,
+  orientation = "horizontal",
+  width = "200px",
+}: SliderProps) => {
+  const [sliderVal, setSliderVal] = useState(value ?? 0);
+
+  const handleSliderChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const newValue = Number(event.target.value);
+    setSliderVal(newValue);
+  };
+
+  // Warning: unreliable
+  const sliderStyle = {
+    width,
+    ...(orientation === "vertical" ? { transform: "rotate(-90deg)" } : {}),
+  }
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+    >
+      <input
+        type="range"
+        name="slider"
+        min={min}
+        max={max}
+        value={sliderVal}
+        step={step ?? "any"}
+        list="slider-markers"
+        style={sliderStyle}
+        onChange={handleSliderChange}
+      />
+      {markers && step && (
+        <datalist id="slider-markers">
+          {Array.from({ length: Math.floor((max - min) / step) + 1 }, (_, i) => min + i * step).map((e) => (
+            // TODO: Supply markers as array and show them here
+            <option key={`slider-marker-${e}`} value={e}></option>
+          ))}
+        </datalist>
+      )}
+      {displayValue && orientation === "horizontal" && <CounterLabel sx={{ml: 2}}>{sliderVal}</CounterLabel>}
+    </Box>
+  )
 };
 
 export default Slider;

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@primer/react";
 
-export interface Props {
+export interface ToolbarProps {
   align?:
     | "center"
     | "flex-start"
@@ -30,7 +30,7 @@ export const Toolbar = ({
   borderBottomColor,
   border = false,
   children,
-}: Props) => {
+}: ToolbarProps) => {
   return (
     <Box
       display="flex"

--- a/src/stories/Slider.stories.tsx
+++ b/src/stories/Slider.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   ThemeProvider,
@@ -22,19 +22,30 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const ThemedSlider = (props: any) =>
-  <ThemeProvider colorMode={props.colorMode}>
-    <BaseStyles>
-      <Slider {...props}>
-      </Slider>
-    </BaseStyles>
-  </ThemeProvider>
+const ThemedSlider = (props: any) => {
+  const [value, setValue] = useState(50);
+
+  return (
+    <ThemeProvider colorMode={props.colorMode}>
+      <BaseStyles>
+        <Slider {...props} value={value} onChange={setValue}>
+        </Slider>
+        {value}
+      </BaseStyles>
+    </ThemeProvider>
+  )
+}
+  
 
 export const SliderDay: Story = {
   args: {
     min: 0,
     max: 100,
     step: 10,
+    value: 50,
+    onChange: (value: number) => {
+      console.log('Slider value changed:', value);
+    },
   },
   render: (args) => <ThemedSlider {...args} colorMode="day" />
 };
@@ -43,7 +54,11 @@ export const SliderNight: Story = {
   args: {
     min: 0,
     max: 100,
-    step: 10
+    step: 10,
+    value: 50,
+    onChange: (value: number) => {
+      console.log('Slider value changed:', value);
+    },
   },
   render: (args) => <ThemedSlider {...args} colorMode="night" />
 };

--- a/src/stories/Slider.stories.tsx
+++ b/src/stories/Slider.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  ThemeProvider,
+  BaseStyles
+} from "@primer/react";
+
+import { Slider } from '../index';
+
+const meta = {
+  title: 'Components/Slider',
+  component: Slider,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
+  tags: ['autodocs'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const ThemedSlider = (props: any) =>
+  <ThemeProvider colorMode={props.colorMode}>
+    <BaseStyles>
+      <Slider {...props}>
+      </Slider>
+    </BaseStyles>
+  </ThemeProvider>
+
+export const SliderDay: Story = {
+  args: {
+    min: 0,
+    max: 100,
+    step: 10,
+  },
+  render: (args) => <ThemedSlider {...args} colorMode="day" />
+};
+
+export const SliderNight: Story = {
+  args: {
+    min: 0,
+    max: 100,
+    step: 10
+  },
+  render: (args) => <ThemedSlider {...args} colorMode="night" />
+};


### PR DESCRIPTION
Fixes #1 

⚠️ There is a weird issue with Docs page where the component is rendered in night mode in both Day and Night

### Day
<img width="100%" alt="Screenshot 2023-05-18 at 10 41 40 PM" src="https://github.com/datalayer/primer-addons/assets/64399555/4d5cad2d-796e-429e-a0cc-b5599a437d7c">

### Night
<img width="100%" alt="Screenshot 2023-05-18 at 10 40 39 PM" src="https://github.com/datalayer/primer-addons/assets/64399555/dbe926aa-1904-41ed-994e-bd52835fe545">
