### PR TITLE
feat: add flash component

### DIFF
--- a/src/components/closeableflash/CloseableFlash.tsx
+++ b/src/components/closeableflash/CloseableFlash.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { Box, Flash, FlashProps } from "@primer/react";
+import { XIcon } from "@primer/octicons-react";
+
+type CloseableFlashProps = FlashProps;
+
+export const CloseableFlash: React.FC<CloseableFlashProps> = (props) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  const handleClose = () => {
+    setIsVisible(false);
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <Flash {...props}>
+      <Box display="flex" justifyContent="space-between" alignItems="center">
+        <Box>{props.children}</Box>
+        <Box onClick={handleClose} sx={{cursor: "pointer"}}>
+          <XIcon size={20}/>
+        </Box>
+      </Box>
+    </Flash>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./components/closeableflash/CloseableFlash";
 export * from "./components/slider/Slider";
 export * from "./components/toolbar/Toolbar";

--- a/src/stories/CloseableFlash.stories.tsx
+++ b/src/stories/CloseableFlash.stories.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  ThemeProvider,
+  BaseStyles,
+  Box
+} from "@primer/react";
+
+import { CloseableFlash } from '../index';
+
+const meta = {
+  title: 'Components/CloseableFlash',
+  component: CloseableFlash,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
+  tags: ['autodocs'],
+  parameters: {
+    // More on how to position stories at: https://storybook.js.org/docs/react/configure/story-layout
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof CloseableFlash>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const ThemedCloseableFlash = (props: any) => {
+  return (
+    <ThemeProvider colorMode={props.colorMode}>
+      <BaseStyles>
+        <Box p={3} bg="canvas.default">
+          <Box>
+            <CloseableFlash {...props}/>
+          </Box>
+        </Box>
+      </BaseStyles>
+    </ThemeProvider>
+  )
+}
+
+export const CloseableFlashDay: Story = {
+  args: {
+    variant: "success"
+  },
+  render: (args) => <ThemedCloseableFlash {...args} colorMode="day">Success Flash</ThemedCloseableFlash>
+};
+
+export const CloseableFlashNight: Story = {
+  args: {
+    variant: "success"
+  },
+  render: (args) => <ThemedCloseableFlash {...args} colorMode="night">Success Flash</ThemedCloseableFlash>
+};


### PR DESCRIPTION
Fixes #8

(Only for representation, the actual story only consists of one flash component, not 4)

<img width="100%" alt="Screenshot 2023-05-22 at 10 56 05 PM" src="https://github.com/datalayer/primer-addons/assets/64399555/d6ea9fee-3ddd-412c-b56a-cdc203851360">
